### PR TITLE
switches to trunc(Int...) instead of relying on div. fixes deprecation warning

### DIFF
--- a/src/Sparklines.jl
+++ b/src/Sparklines.jl
@@ -10,11 +10,11 @@ spark(itr) = spark(STDOUT, itr)
 function spark(io::IO, itr)
     values = collect(itr)
     min, max = extrema(values)
-    
+
     f = div((max - min) * 2^8, length(ticks)-1)
     f < 1 && (f = 1)
-    
-    idxs = div(((values .- min) * 2^8), f)
+
+    idxs = trunc(Int, ((values .- min) * 2^8) / f)
     print(io, utf8(ticks[idxs.+1]))
 end
 


### PR DESCRIPTION
`div` with floating point arguments returns a floating point result. Indexing
with floating points is now deprecated, so this uses `trunc(Int, ...)` to
keep the indices integers. Tests still pass.
